### PR TITLE
Change `commands` to read directly from /dev/auditpipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ sudo auditpipe -fr,-fw | praudit -lx | grep /Users/me
 
 ### `commands`
 
-If you ever need to see which commands are being run by other processes, this is the tool to do that. Prints the command lines for all processes. The `commands` tool reads from either `auditpipe` or from `/var/audit` logs.
+If you ever need to see which commands are being run by other processes, this is the tool to do that. Prints the command lines for all processes. The `commands` tool reads log files, for example those in `/var/audit`, or if no log file is provided `commands` shows live commands via `/dev/auditpipe`.
 
 #### Examples
 
 ```sh
-sudo auditpipe +pc | commands
+sudo commands
 sudo commands /var/audit/current
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ If you ever need to see which commands are being run by other processes, this is
 #### Examples
 
 ```sh
-sudo commands
-sudo commands /var/audit/current
+commands
+commands /var/audit/current
 ```
 
 ### `auditon`

--- a/commands.cpp
+++ b/commands.cpp
@@ -1,5 +1,10 @@
 #include <bsm/libbsm.h>
+#include <cstdio>
 #include <cstdlib>
+#include <memory>
+#include <security/audit/audit_ioctl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
 
 // Print the strings in a given au_execarg_t or au_execenv_t record.
 template <typename T>
@@ -11,20 +16,110 @@ static void printStrings(const T &strings, const char *term) {
   printf("%s", term);
 }
 
-int main(int argc, char **argv) {
-  FILE *input = stdin;
-  if (argc > 1) {
-    input = fopen(argv[1], "r");
-    if (not input) {
-      perror("error");
-      return EXIT_FAILURE;
+using unique_file_ptr = std::unique_ptr<FILE, decltype(&fclose)>;
+
+static unique_file_ptr file_open(const char *path, const char *mode) {
+  return {fopen(path, mode), &fclose};
+}
+
+static unique_file_ptr auditpipe() {
+  auto pipe = file_open("/dev/auditpipe", "r");
+  unique_file_ptr null_file{nullptr, &fclose};
+  if (not pipe) {
+    return null_file;
+  }
+
+  //
+  // Setup the `ex` event class. This is a hypothetical optimization.
+  //
+  // By default, the `pc` class includes the two events we want, `execve` and
+  // `posix_spawn`, while the `ex` event class includes only `execve`. However,
+  // the `pc` event class includes many other event's we're not interested in,
+  // while the `ex` event class has very few events.
+  {
+    auto event_num = getauevnonam("AUE_POSIX_SPAWN");
+    if (not event_num) {
+      return null_file;
+    }
+
+    au_evclass_map_t evc_map{};
+    evc_map.ec_number = *event_num;
+    if (audit_get_class(&evc_map, sizeof(evc_map))) {
+      return null_file;
+    }
+
+    auto class_ent = getauclassnam("ex");
+    if (not class_ent) {
+      return null_file;
+    }
+
+    auto current_mask = evc_map.ec_class;
+    evc_map.ec_class |= class_ent->ac_class;
+    if (evc_map.ec_class != current_mask) {
+      if (audit_set_class(&evc_map, sizeof(evc_map))) {
+        return null_file;
+      }
     }
   }
 
-  while (feof(input) == 0) {
+  //
+  // See man auditpipe for details on these auditpipe ioctls.
+  {
+    auto fd = fileno(pipe.get());
+    int mode = AUDITPIPE_PRESELECT_MODE_LOCAL;
+    if (ioctl(fd, AUDITPIPE_SET_PRESELECT_MODE, &mode)) {
+      return null_file;
+    }
+
+    // Increase the event queue to the largest maximum size.
+    u_int max_qlimit;
+    if (ioctl(fd, AUDITPIPE_GET_QLIMIT_MAX, &max_qlimit) ||
+        ioctl(fd, AUDITPIPE_SET_QLIMIT, &max_qlimit)) {
+      return null_file;
+    }
+
+    au_mask_t masks;
+    if (getauditflagsbin((char *)"+ex", &masks)) {
+      return null_file;
+    }
+
+    if (ioctl(fd, AUDITPIPE_SET_PRESELECT_FLAGS, &masks)) {
+      return null_file;
+    }
+  }
+
+  return pipe;
+}
+
+int main(int argc, char **argv) {
+  if (argc == 1 && not isatty(STDIN_FILENO)) {
+    fprintf(stderr, "usage: %s [<audit-log>]\n", argv[0]);
+    return EXIT_FAILURE;
+  }
+
+  if (geteuid() != 0) {
+    // Re-exec with sudo.
+    // TODO: This doesn't need to be in the uncommon case of reading from audit
+    // log files owned by the user.
+    const char *cmd[argc + 2];
+    cmd[0] = "sudo";
+    for (int i = 0; i < argc; ++i) {
+      cmd[i + 1] = argv[i];
+    }
+    cmd[argc + 1] = nullptr;
+    execvp("sudo", (char **)cmd);
+  }
+
+  unique_file_ptr input = argc > 1 ? file_open(argv[1], "r") : auditpipe();
+  if (not input) {
+    perror("error");
+    return EXIT_FAILURE;
+  }
+
+  while (feof(input.get()) == 0) {
     // Read an audit event, which is a buffer of tokens.
     u_char *buffer = nullptr;
-    const auto record_size = au_read_rec(input, &buffer);
+    const auto record_size = au_read_rec(input.get(), &buffer);
     if (record_size == 0) {
       // End of input.
       break;


### PR DESCRIPTION
Previously, in order to print commands being executed live as they happened,  `commands` expected the `auditpipe` command to be piped into it, for example:

```sh
$ sudo auditpipe +pc | commands
```

This change enables `commands` to read directly form `/dev/auditpipe`. This makes the command line interface simpler, you no longer need to know which event class to observe.

In addition, `commands` will now re-exec with `sudo` if needed. This means the command line is as simple as:

```sh
$ commands
```