### PR TITLE
Remove unnecessary sudo from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ brew install --HEAD kastiglione/formulae/knox
 Opens and configures the audit event firehose: `/dev/auditpipe`. The `auditpipe` command takes a set of event classes, and writes all matching events to `stdout`. A quick example to consider:
 
 ```sh
-sudo auditpipe pc,fc | praudit -lx
+auditpipe pc,fc | praudit -lx
 ```
 
 Using `praudit` (ships with macOS), this prints process events ("pc" event class) and file creation events ("fc" event class). See [Event Classes](#event-classes) for a list. The process event class includes syscalls such as `fork`, `execve`, `posix_spawn`, `kill`, `exit`, and more. The syscalls and their associated event classes are listed in `/etc/security/audit_event`.
@@ -35,13 +35,13 @@ The complete list of event classes can be found in `/etc/security/audit_classes`
 ##### Print successful process events:
 
 ```sh
-sudo auditpipe +pc | praudit -lx
+auditpipe +pc | praudit -lx
 ```
 
 ##### Print failed file reads and writes, and filters to the given path prefix:
 
 ```sh
-sudo auditpipe -fr,-fw | praudit -lx | grep /Users/me
+auditpipe -fr,-fw | praudit -lx | grep /Users/me
 ```
 
 ### `commands`
@@ -129,11 +129,7 @@ sudo chmod +s auditpipe
 
 #### sudo
 
-Shell aliases can be used to always use `sudo`:
-
-```sh
-alias auditpipe='sudo auditpipe'
-```
+Where necessary, `knox` commands will re-exec with `sudo`, prompting the user to enter their password, if necessary.
 
 To make `sudo auditpipe` require no password, run `sudo visudo` and then add:
 

--- a/auditpipe.cpp
+++ b/auditpipe.cpp
@@ -1,15 +1,3 @@
-/*
-  usage:
-  sudo %s [flags] | praudit
-  sudo %s [flags] > log
-
-  docs:
-  man audit_class audit_event audit_control
-
-  example:
-  sudo %s +pc,fc,-fr | praudit
-*/
-
 #include <bsm/libbsm.h>
 #include <cstdio>
 #include <cstdlib>
@@ -37,7 +25,11 @@ static void stop_running(int _signal) { keep_running = false; }
 
 int main(int argc, char **argv) {
   if (argc != 2 || strcmp(argv[1], "-h") == 0) {
-    fprintf(stderr, "usage: %s <event-classes>\n", argv[0]);
+    fprintf(stderr,
+            "usage:\n"
+            "\t%s <event-classes> | praudit\n"
+            "\t%s <event-classes> > /path/to/log\n",
+            argv[0], argv[0]);
     return EXIT_FAILURE;
   }
 
@@ -50,8 +42,8 @@ int main(int argc, char **argv) {
 
   if (geteuid() != 0) {
     // Re-exec with sudo.
-    char *cmd[] = {"sudo", argv[0], argv[1], nullptr};
-    execvp("sudo", cmd);
+    const char *cmd[] = {"sudo", argv[0], argv[1], nullptr};
+    execvp("sudo", (char **)cmd);
   }
 
   if (isatty(STDOUT_FILENO)) {


### PR DESCRIPTION
Commit 97a75f0b6d9c82d399b48b7a0be807a10880c2a0 added the ability to re-exec with `sudo`. This updates the README to remove the explicit use of `sudo` which is now no longer required.

In addition, in `auditpipe.cpp`:
* fixed comments
* fixed usage string
* fixed writable string compiler warning 