### PR TITLE
Fix file descriptor sharing after re-exec

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
   }
 
   if (geteuid() != 0) {
-    // Re-exec with sudo.
+    std::cout << "Re-running as root" << std::endl;
     // TODO: This doesn't need to be in the uncommon case of reading from audit
     // log files owned by the user.
     const char *cmd[argc + 2];


### PR DESCRIPTION
Previously if you ran `commands | grep foo`, it would never output
anything. This seems to be because the file descriptor isn't shared with
the exec'd process unless it is open https://stackoverflow.com/a/55502228/902968

This does the simplest version of opening by also printing it's
re-execuing as root, which explains the password prompt you see.