### PR TITLE
Add macOS version to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
-CXXFLAGS := -Wall -std=c++14 -O2
+CXXFLAGS := -Wall -std=c++14 -O2 -mmacos-version-min=10.10 -lbsm
 
 all: auditon auditpipe commands paudit pwait
 
 auditon: auditon.cpp
-	xcrun -sdk macosx clang++ $(CXXFLAGS) -lbsm -o $@ auditon.cpp
+	xcrun -sdk macosx clang++ $(CXXFLAGS) -o $@ auditon.cpp
 
 auditpipe: auditpipe.cpp
-	xcrun -sdk macosx clang++ $(CXXFLAGS) -lbsm -o $@ auditpipe.cpp
+	xcrun -sdk macosx clang++ $(CXXFLAGS) -o $@ auditpipe.cpp
 
 commands: commands.cpp
-	xcrun -sdk macosx clang++ $(CXXFLAGS) -lbsm -o $@ commands.cpp
+	xcrun -sdk macosx clang++ $(CXXFLAGS) -o $@ commands.cpp
 
 paudit: paudit.cpp
-	xcrun -sdk macosx clang++ $(CXXFLAGS) -lbsm -o $@ paudit.cpp
+	xcrun -sdk macosx clang++ $(CXXFLAGS) -o $@ paudit.cpp
 
 pwait: pwait.cpp
-	xcrun -sdk macosx clang++ $(CXXFLAGS) -lbsm -o $@ pwait.cpp
+	xcrun -sdk macosx clang++ $(CXXFLAGS) -o $@ pwait.cpp


### PR DESCRIPTION
Many bsm APIs were deprecated in macOS 11.0, this avoids those warnings for now