### PR TITLE
Handle args / env over max expected size

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -182,7 +182,12 @@ int main(int argc, char **argv) {
       }
       std::string full_path{path.path, path.len};
       auto args = shellJoin(full_path, exec_args.text, std::min<uint32_t>(exec_args.count, AUDIT_MAX_ARGS));
-      std::cout << args << std::endl;
+      std::cout << args;
+      bool truncated = exec_env.count >= AUDIT_MAX_ENV || exec_args.count >= AUDIT_MAX_ARGS;
+      if (truncated) {
+        std::cout << " [[WARNING - TRUNCATED]]";
+      }
+      std::cout << std::endl;
     }
 
     free(buffer);

--- a/commands.cpp
+++ b/commands.cpp
@@ -177,11 +177,11 @@ int main(int argc, char **argv) {
     // If the audit tokens had exec args, print them (and optionally env too).
     if (exec_args.count > 0) {
       if (exec_env.count > 0) {
-        auto env = shellJoin(exec_env.text, exec_env.count);
+        auto env = shellJoin(exec_env.text, std::min<uint32_t>(exec_env.count, AUDIT_MAX_ENV));
         std::cout << env << " ";
       }
       std::string full_path{path.path, path.len};
-      auto args = shellJoin(full_path, exec_args.text, exec_args.count);
+      auto args = shellJoin(full_path, exec_args.text, std::min<uint32_t>(exec_args.count, AUDIT_MAX_ARGS));
       std::cout << args << std::endl;
     }
 


### PR DESCRIPTION
It seems that the count of the args can sometimes exceed the
AUDIT_MAX_ARGS, eventually resulting in a crash / asan violation when
calling strchr on the string. This makes sure that commands doesn't
crash, but realistically this can mean some args are ignored in the
final output. It seems like this is the best we can do in this case.
